### PR TITLE
Feature/login with spotify

### DIFF
--- a/FindMySong/Controllers/SearchViewController.swift
+++ b/FindMySong/Controllers/SearchViewController.swift
@@ -1,0 +1,219 @@
+import UIKit
+
+class SearchViewController: UIViewController {
+    
+    let titleLabel: UILabel = {
+        let titleLabel = UILabel()
+        
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        let fullTitle = "find my Song"
+        titleLabel.textAlignment = .left
+        
+        let attributedText = NSMutableAttributedString(
+            string: fullTitle,
+            attributes: [.font: UIFont.systemFont(ofSize: 32, weight: .regular)]
+        )
+        if let range = fullTitle.range(of: "Song") {
+            let nsRange = NSRange(range, in: fullTitle)
+            attributedText.addAttribute(.font, value: UIFont.systemFont(ofSize: 32, weight: .bold), range: nsRange)
+        }
+        titleLabel.attributedText = attributedText
+        
+        return titleLabel
+    }()
+    
+    let searchBar: UISearchBar = {
+        let searchBar = UISearchBar()
+        searchBar.placeholder = "Find your favorite song, band or album"
+        searchBar.searchBarStyle = .minimal
+        searchBar.backgroundImage = UIImage()
+        searchBar.translatesAutoresizingMaskIntoConstraints = false
+        
+        //Do contrário, o ícone era criado, mas não adicionado a rightView
+        DispatchQueue.main.async {
+            let textField = searchBar.searchTextField
+            
+            textField.translatesAutoresizingMaskIntoConstraints = false
+            
+            //Para remover o excesso de espaçamento nas laterais da searchbar
+            NSLayoutConstraint.activate([
+                textField.leadingAnchor.constraint(equalTo: searchBar.leadingAnchor),
+                textField.trailingAnchor.constraint(equalTo: searchBar.trailingAnchor),
+            ])
+            
+            let microphoneIcon = UIButton(type: .system)
+            microphoneIcon.setImage(UIImage(systemName: "mic.fill"), for: .normal)
+            microphoneIcon.tintColor = .gray
+            microphoneIcon.frame = CGRect(x: 0, y: 0, width: 24, height: 24)
+            microphoneIcon.contentMode = .scaleAspectFit
+            textField.rightView = microphoneIcon
+            textField.rightViewMode = .always
+        }
+        return searchBar
+    }()
+    
+    let segmentedControl: UISegmentedControl = {
+        let items = ["Band", "Song", "Album"]
+        let segmentedControl = UISegmentedControl(items: items)
+        
+        segmentedControl.selectedSegmentIndex = 1
+        segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+        
+        return segmentedControl
+    }()
+    
+    let tabBar: UITabBar = {
+        let tabBar = UITabBar()
+        tabBar.translatesAutoresizingMaskIntoConstraints = false
+        
+        let search = UITabBarItem(title: "Search", image: UIImage(systemName: "magnifyingglass"), tag: 0)
+        let profile = UITabBarItem(title: "Profile", image: UIImage(systemName: "person"), tag: 1)
+        let settings = UITabBarItem(title: "Settings", image: UIImage(systemName: "gear"), tag: 2)
+        
+        tabBar.items = [search, profile, settings]
+        tabBar.selectedItem = search
+        tabBar.backgroundColor = .systemBackground
+        tabBar.isTranslucent = false
+        
+        return tabBar
+        
+    }()
+    
+    let emptyIcon: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "square.dashed")
+        
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        
+        let red: CGFloat = 120 / 255.0
+        let green: CGFloat = 120 / 255.0
+        let blue: CGFloat = 128 / 255.0
+        let alpha: CGFloat = 31 / 255.0
+        
+        imageView.tintColor = UIColor(red: red, green: green, blue: blue, alpha: alpha)
+        
+        return imageView
+    }()
+    
+    let emptyListMessage: UILabel = {
+        let label = UILabel()
+        label.text = "Nothing here. Try searching for a song."
+     
+        label.font = .systemFont(ofSize: 17, weight: .semibold)
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        let red: CGFloat = 60 / 255.0
+        let green: CGFloat = 60 / 255.0
+        let blue: CGFloat = 67 / 255.0
+        let alpha: CGFloat = 0.3
+        
+        label.textColor = UIColor(red: red, green: green, blue: blue, alpha: alpha)
+        
+        return label
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        navigationItem.hidesBackButton = true
+        
+        // MARK: - Stack View Principal
+        let mainStackView = UIStackView()
+        mainStackView.axis = .vertical
+        mainStackView.spacing = 0
+        mainStackView.alignment = .fill
+        mainStackView.distribution = .fill
+        mainStackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        view.addSubview(mainStackView)
+        
+        NSLayoutConstraint.activate([
+            mainStackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 32),
+            mainStackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -32),
+            mainStackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: -28)
+        ])
+        
+        //MARK: TitleView
+        let titleView = UIView()
+        
+        titleView.addSubview(titleLabel)
+        
+        mainStackView.addArrangedSubview(titleView)
+        
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: titleView.topAnchor),
+            titleLabel.bottomAnchor.constraint(equalTo: titleView.bottomAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: mainStackView.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: mainStackView.trailingAnchor)
+        ])
+        
+        //MARK: SearchbarView
+        let searchBarView = UIView()
+        
+        searchBarView.addSubview(searchBar)
+        
+        mainStackView.addArrangedSubview(searchBarView)
+        
+        NSLayoutConstraint.activate([
+            searchBar.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: 45),
+            searchBar.bottomAnchor.constraint(equalTo: searchBarView.bottomAnchor),
+            searchBar.leadingAnchor.constraint(equalTo: mainStackView.leadingAnchor),
+            searchBar.trailingAnchor.constraint(equalTo: mainStackView.trailingAnchor)
+        ])
+        
+        
+        //MARK: SegmentedControlView
+        let segmentedControlView = UIView()
+        
+        segmentedControlView.addSubview(segmentedControl)
+        
+        mainStackView.addArrangedSubview(segmentedControlView)
+        
+        NSLayoutConstraint.activate([
+            segmentedControl.topAnchor.constraint(equalTo: searchBarView.bottomAnchor),
+            segmentedControl.bottomAnchor.constraint(equalTo: segmentedControlView.bottomAnchor),
+            segmentedControl.leadingAnchor.constraint(equalTo: mainStackView.leadingAnchor),
+            segmentedControl.trailingAnchor.constraint(equalTo: mainStackView.trailingAnchor)
+        ])
+        
+        //MARK: Segmented ContentView
+        
+        let contentView = UIView()
+        
+        contentView.addSubview(emptyIcon)
+        contentView.addSubview(emptyListMessage)
+        
+        mainStackView.addArrangedSubview(contentView)
+        
+        NSLayoutConstraint.activate([
+            emptyIcon.topAnchor.constraint(equalTo: segmentedControlView.bottomAnchor, constant: 200),
+            emptyIcon.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            emptyIcon.leadingAnchor.constraint(equalTo: mainStackView.leadingAnchor),
+            emptyIcon.trailingAnchor.constraint(equalTo: mainStackView.trailingAnchor),
+            emptyIcon.heightAnchor.constraint(equalToConstant: 100),
+            
+            emptyListMessage.topAnchor.constraint(equalTo: emptyIcon.bottomAnchor, constant: 36),
+            emptyListMessage.bottomAnchor.constraint(equalTo: mainStackView.bottomAnchor),
+            emptyListMessage.leadingAnchor.constraint(equalTo: mainStackView.leadingAnchor),
+            emptyListMessage.trailingAnchor.constraint(equalTo: mainStackView.trailingAnchor)
+        ])
+        
+        //MARK: TabBarView
+        let tabBarView = UIView()
+        
+        tabBarView.addSubview(tabBar)
+        
+        mainStackView.addArrangedSubview(tabBarView)
+        
+        NSLayoutConstraint.activate([
+            tabBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tabBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tabBar.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            tabBar.heightAnchor.constraint(equalToConstant: 50)
+        ])
+    }
+}

--- a/FindMySong/Controllers/SpotifyWebViewController.swift
+++ b/FindMySong/Controllers/SpotifyWebViewController.swift
@@ -1,0 +1,40 @@
+//
+//  SpotifyWebViewController.swift
+//  FindMySong
+//
+//  Created by henrique.cisi on 05/06/25.
+//
+
+import UIKit
+import WebKit
+
+class SpotifyWebViewController: UIViewController, WKNavigationDelegate {
+
+    private var webView: WKWebView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Login with Spotify"
+        view.backgroundColor = .systemBackground
+
+        webView = WKWebView(frame: .zero)
+        webView.navigationDelegate = self
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(webView)
+
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        if let url = SpotifyService.shared.getAuthURL() as URL? {
+            webView.load(URLRequest(url: url))
+        }
+    }
+
+    @objc private func closeWebView() {
+        dismiss(animated: true)
+    }
+}

--- a/FindMySong/Controllers/SpotifyWebViewController.swift
+++ b/FindMySong/Controllers/SpotifyWebViewController.swift
@@ -8,33 +8,57 @@
 import UIKit
 import WebKit
 
+protocol SpotifyWebViewControllerDelegate: AnyObject {
+    func spotifyWebViewController(_ controller: SpotifyWebViewController, didReceiveCode code: String)
+}
+
 class SpotifyWebViewController: UIViewController, WKNavigationDelegate {
-
+    
     private var webView: WKWebView!
-
+    
+    weak var delegate: SpotifyWebViewControllerDelegate?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Login with Spotify"
         view.backgroundColor = .systemBackground
-
+        
         webView = WKWebView(frame: .zero)
         webView.navigationDelegate = self
         webView.translatesAutoresizingMaskIntoConstraints = false
+        
         view.addSubview(webView)
-
+        
         NSLayoutConstraint.activate([
             webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             webView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
-
-        if let url = SpotifyService.shared.getAuthURL() as URL? {
+        
+        if let url = SpotifyService.shared.getSpotifyAuthURL() as URL? {
             webView.load(URLRequest(url: url))
         }
     }
-
-    @objc private func closeWebView() {
-        dismiss(animated: true)
+    
+    // MARK: - Interceptor method
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.allow)
+            return
+        }
+        
+        let service = SpotifyService.shared
+        
+        if service.isSpotifyCallbackUrlValid(url),
+           let code = service.getSpotifyAccessCode(from: url) {
+            
+            delegate?.spotifyWebViewController(self, didReceiveCode: code)
+            dismiss(animated: true)
+            decisionHandler(.cancel)
+        } else {
+            decisionHandler(.allow)
+        }
     }
 }

--- a/FindMySong/Controllers/ViewController.swift
+++ b/FindMySong/Controllers/ViewController.swift
@@ -36,7 +36,9 @@ class ViewController: UIViewController, SpotifyWebViewControllerDelegate{
             preferredStyle: .alert
         )
 
-        alert.addAction(UIAlertAction(title: "Não", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Não", style: .default) { _ in
+            UserDefaults.standard.set(false, forKey: "prefersBiometricAuthentication")
+        })
 
         alert.addAction(UIAlertAction(title: "Sim", style: .default) { _ in
             UserDefaults.standard.set(true, forKey: "prefersBiometricAuthentication")
@@ -360,9 +362,12 @@ class ViewController: UIViewController, SpotifyWebViewControllerDelegate{
         let searchVC = SearchViewController()
         navigationController?.pushViewController(searchVC, animated: true)
         
+        let hasBiometryPreference = UserDefaults.standard.bool(forKey: "prefersBiometricAuthentication")
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.present(self.biometricPromptAlert, animated: true)
+        if(!hasBiometryPreference){
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.present(self.biometricPromptAlert, animated: true)
+            }
         }
     }
 }

--- a/FindMySong/Controllers/ViewController.swift
+++ b/FindMySong/Controllers/ViewController.swift
@@ -13,6 +13,14 @@ class ViewController: UIViewController, SpotifyWebViewControllerDelegate{
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
+    
+    private lazy var loadingView: UIView = {
+            let view = UIView()
+            view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .systemBackground
+            view.isHidden = true
+            return view
+        }()
 
     private lazy var spinner: UIActivityIndicatorView = {
         let spinner = UIActivityIndicatorView(style: .large)
@@ -68,8 +76,14 @@ class ViewController: UIViewController, SpotifyWebViewControllerDelegate{
             mainStackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
         
-        view.addSubview(spinner)
+        view.addSubview(loadingView)
+        loadingView.addSubview(spinner)
+        
         NSLayoutConstraint.activate([
+            loadingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            loadingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            loadingView.topAnchor.constraint(equalTo: view.topAnchor),
+            loadingView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             spinner.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             spinner.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
@@ -245,10 +259,12 @@ class ViewController: UIViewController, SpotifyWebViewControllerDelegate{
     
     //MARK: Login methods
     private func fetchTokens(with code: String) {
+        loadingView.isHidden = false
         spinner.startAnimating()
         
         Task {
             defer {
+                loadingView.isHidden = true
                 spinner.stopAnimating()
             }
             

--- a/FindMySong/Controllers/ViewController.swift
+++ b/FindMySong/Controllers/ViewController.swift
@@ -1,11 +1,9 @@
 //
-//  ViewController.swift
-//  FindMySong
-//
 //  Created by saulo.santos.freire on 26/03/25.
 //
 
 import UIKit
+import SafariServices
 
 class ViewController: UIViewController {
     
@@ -17,7 +15,7 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         view.backgroundColor = .systemBackground
         
         let mainStackView = UIStackView()
@@ -78,6 +76,8 @@ class ViewController: UIViewController {
         loginWithSpotifyButton.tintColor = .black
         loginWithSpotifyButton.layer.cornerRadius = 25
         loginWithSpotifyButton.translatesAutoresizingMaskIntoConstraints = false
+        
+        loginWithSpotifyButton.addTarget(self, action: #selector(onLoginWithSpotifyPressed), for: .touchUpInside)
         
         buttonsView.addSubview(loginWithSpotifyButton)
         
@@ -181,5 +181,12 @@ class ViewController: UIViewController {
         gradientLayer.mask = textMask
         containerView.layer.addSublayer(gradientLayer)
     }
+    
+    //  MARK:  Button Methods
+    @objc private func onLoginWithSpotifyPressed() {
+        let webVC = SpotifyWebViewController()
+        let nav = UINavigationController(rootViewController: webVC)
+        nav.modalPresentationStyle = .formSheet
+        present(nav, animated: true)
+    }
 }
-

--- a/FindMySong/Info.plist
+++ b/FindMySong/Info.plist
@@ -29,5 +29,8 @@
         </array>
       </dict>
     </array>
+    
+    <key>NSFaceIDUsageDescription</key>
+    <string>Será utilizado para facilitar o login, de forma mais segura e rápida</string>
 </dict>
 </plist>

--- a/FindMySong/Info.plist
+++ b/FindMySong/Info.plist
@@ -19,5 +19,15 @@
 			</array>
 		</dict>
 	</dict>
+    
+    <key>CFBundleURLTypes</key>
+    <array>
+      <dict>
+        <key>CFBundleURLSchemes</key>
+        <array>
+          <string>fms</string>
+        </array>
+      </dict>
+    </array>
 </dict>
 </plist>

--- a/FindMySong/SceneDelegate.swift
+++ b/FindMySong/SceneDelegate.swift
@@ -15,9 +15,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             guard let windowScene = scene as? UIWindowScene else { return }
             
             let window = UIWindow(windowScene: windowScene)
-            let rootViewController = ViewController()
-            
-            window.rootViewController = rootViewController
+        
+            let navigationController = UINavigationController(rootViewController: ViewController())
+        
+            window.rootViewController = navigationController
             self.window = window
             window.makeKeyAndVisible()
     }

--- a/FindMySong/Secrets.plist
+++ b/FindMySong/Secrets.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+   Secrets.plist
+   FindMySong
+
+   Created by henrique.cisi on 05/06/25.
+    
+   Para fins de avaliação, as credenciais estão hardcoded
+-->
+<plist version="1.0">
+    <dict>
+        <key>SPOTIFY_CLIENT_ID</key>
+        <string>e2fc8bf189174ef196832cf74c1126a8</string>
+        <key>SPOTIFY_CLIENT_SECRET</key>
+        <string>f9223ab6998f4b3497c96e02d8bc2f90</string>
+    </dict>
+</plist>

--- a/FindMySong/Services/BiometryService.swift
+++ b/FindMySong/Services/BiometryService.swift
@@ -1,0 +1,45 @@
+//
+//  BiometryService.swift
+//  FindMySong
+//
+//  Created by henrique.cisi on 10/06/25.
+//
+
+import LocalAuthentication
+
+final class BiometryService {
+
+    enum BiometryResult {
+        case success
+        case failure(Error?)
+        case notAvailable
+    }
+
+    static let shared = BiometryService()
+
+    private let context = LAContext()
+
+    private init() {}
+
+    func isBiometryAvailable() -> Bool {
+        var error: NSError?
+        return context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
+    }
+
+    func authenticateUser(reason: String = "Autenticação com biometria", completion: @escaping (BiometryResult) -> Void) {
+        guard isBiometryAvailable() else {
+            completion(.notAvailable)
+            return
+        }
+
+        context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason) { success, error in
+            DispatchQueue.main.async {
+                if success {
+                    completion(.success)
+                } else {
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+}

--- a/FindMySong/Services/KeyChainService.swift
+++ b/FindMySong/Services/KeyChainService.swift
@@ -1,0 +1,90 @@
+//
+//  KeyChainService.swift
+//  FindMySong
+//
+//  Created by henrique.cisi on 06/06/25.
+//
+
+import Foundation
+import Security
+
+enum KeychainOperation: String {
+    case add = "add"
+    case delete = "delete"
+    case update = "update"
+    case read = "read"
+}
+
+enum KeyChainService {
+    
+    //MARK: Keychain public methods
+    static func create(value: String, forKey key: String) -> Bool {
+        
+        guard let data = value.data(using: .utf8) else { return false}
+        
+        var query = formatQuery(forKey: key)
+        
+        SecItemDelete(query as CFDictionary)
+        
+        query[kSecValueData as String] = data
+        
+        let hasSaved = SecItemAdd(query as CFDictionary, nil)
+        
+        return checkOperationStatus(hasSaved, operation: .add)
+    }
+    
+    static func read(forKey key: String) -> String? {
+        var query = formatQuery(forKey: key)
+            query[kSecReturnData as String] = kCFBooleanTrue
+            query[kSecMatchLimit as String] = kSecMatchLimitOne
+            
+            var value: CFTypeRef?
+            let hasRead = SecItemCopyMatching(query as CFDictionary, &value)
+            
+            guard checkOperationStatus(hasRead, operation: .read) else { return nil }
+        
+            guard let data = value as? Data,
+                  let value = String(data: data, encoding: .utf8) else {
+                return nil
+            }
+            return value
+    }
+    
+    static func update(value: String, forKey key: String) -> Bool {
+        guard let data = value.data(using: .utf8) else { return false }
+        
+        let query = formatQuery(forKey: key)
+        
+        let attributesToUpdate: [String: Any] = [
+            kSecValueData as String: data
+        ]
+        
+        let hasUpdated = SecItemUpdate(query as CFDictionary, attributesToUpdate as CFDictionary)
+        
+        return checkOperationStatus(hasUpdated, operation: .update)
+    }
+    
+    static func delete(forKey key: String) -> Bool {
+        let query = formatQuery(forKey: key)
+        
+        let hasRemoved = SecItemDelete(query as CFDictionary)
+
+        return checkOperationStatus(hasRemoved, operation: .delete)
+    }
+    
+    //MARK: Private helpers
+    private static func formatQuery(forKey key: String) -> [String: Any] {
+        return [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+    }
+    
+    private static func checkOperationStatus(_ status: OSStatus, operation: KeychainOperation) -> Bool {
+        switch (operation, status) {
+        case (_, errSecSuccess): return true
+        case(.delete, errSecItemNotFound): return true
+        default : return false
+        }
+    }
+}

--- a/FindMySong/Services/SpotifyService.swift
+++ b/FindMySong/Services/SpotifyService.swift
@@ -113,6 +113,7 @@ final class SpotifyService {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue(formatAuthorizationHeader(), forHTTPHeaderField: "Authorization")
         
         let queryParams = [
             "grant_type": "refresh_token",
@@ -122,7 +123,6 @@ final class SpotifyService {
         let queryString = self.formatQueryString(with: queryParams)
         
         request.httpBody = queryString.data(using: .utf8)
-        
         return request
     }
     

--- a/FindMySong/Services/SpotifyService.swift
+++ b/FindMySong/Services/SpotifyService.swift
@@ -9,15 +9,33 @@ import Foundation
 
 final class SpotifyService {
     static let shared = SpotifyService()
-
-    private let clientId = "e2fc8bf189174ef196832cf74c1126a8"
+    
+    // MARK: - Private Properties
+    private let clientId: String
+    private let clientSecret: String
     private let redirectURI = "fms://login/callback"
     private let scopes = "user-read-private playlist-modify-public playlist-read-public user-follow-read user-read-email"
     private let authorizeBaseURL = "https://accounts.spotify.com/authorize"
     private let responseType = "code"
     private let showDialog = "true"
-
-    func getAuthURL() -> URL? {
+    private let tokenBaseURL = "https://accounts.spotify.com/api/token"
+    
+    //MARK: - Init()
+    private init() {
+        guard let path = Bundle.main.path(forResource: "Secrets", ofType: "plist"),
+              let dict = NSDictionary(contentsOfFile: path),
+              let clientId = dict["SPOTIFY_CLIENT_ID"] as? String,
+              let clientSecret = dict["SPOTIFY_CLIENT_SECRET"] as? String else {
+            fatalError("Secrets.plist missing or keys not found")
+        }
+        
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+    }
+    
+    
+    // MARK: - Public Methods
+    func getSpotifyAuthURL() -> URL? {
         var components = URLComponents(string: authorizeBaseURL)
         components?.queryItems = [
             URLQueryItem(name: "client_id", value: clientId),
@@ -27,6 +45,69 @@ final class SpotifyService {
             URLQueryItem(name: "show_dialog", value: showDialog)
         ]
         return components?.url
+    }
+    
+    func requestAccessToken(withCode code: String) async throws -> (accessToken: String, refreshToken: String) {
+        guard let request = createRequest(with: code) else {
+            throw NSError(domain: "Invalid Request", code: -1)
+        }
+        
+        let (data, _) = try await URLSession.shared.data(for: request)
+        
+        guard let tokens = self.parseResponse(with: data) else {
+            throw NSError(domain: "Invalid Response", code: -1)
+        }
+        
+        return tokens
+    }
+    
+    func isSpotifyCallbackUrlValid(_ url: URL) -> Bool {
+        return url.scheme == "fms" && url.host == "login" && url.path == "/callback"
+    }
+    
+    func getSpotifyAccessCode(from url: URL) -> String? {
+        return URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?.first(where: { $0.name == "code" })?.value
+    }
+    
+    // MARK: - Private Helpers
+    private func createRequest(with code: String) -> URLRequest? {
+        guard let url = URL(string: tokenBaseURL) else { return nil }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue(formatAuthorizationHeader(), forHTTPHeaderField: "Authorization")
+        
+        let queryParams = [
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirectURI
+        ]
+        
+        let queryString = self.formatQueryString(with: queryParams)
+        
+        request.httpBody = queryString.data(using: .utf8)
+        
+        return request
+    }
+    
+    private func formatAuthorizationHeader() -> String {
+        let credentials = "\(clientId):\(clientSecret)"
+        let base64 = Data(credentials.utf8).base64EncodedString()
+        return "Basic \(base64)"
+    }
+    
+    private func formatQueryString(with params: [String : String] ) -> String {
+        return params.map { "\($0.key)=\($0.value)" }.joined(separator: "&")
+    }
+    
+    private func parseResponse(with data: Data) -> (accessToken: String, refreshToken: String)? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accessToken = json["access_token"] as? String,
+              let refreshToken = json["refresh_token"] as? String else {
+            return nil
+        }
+        return (accessToken, refreshToken)
     }
 }
 

--- a/FindMySong/Services/SpotifyService.swift
+++ b/FindMySong/Services/SpotifyService.swift
@@ -1,0 +1,32 @@
+//
+//  SpotifyService.swift
+//  FindMySong
+//
+//  Created by henrique.cisi on 05/06/25.
+//
+
+import Foundation
+
+final class SpotifyService {
+    static let shared = SpotifyService()
+
+    private let clientId = "e2fc8bf189174ef196832cf74c1126a8"
+    private let redirectURI = "fms://login/callback"
+    private let scopes = "user-read-private playlist-modify-public playlist-read-public user-follow-read user-read-email"
+    private let authorizeBaseURL = "https://accounts.spotify.com/authorize"
+    private let responseType = "code"
+    private let showDialog = "true"
+
+    func getAuthURL() -> URL? {
+        var components = URLComponents(string: authorizeBaseURL)
+        components?.queryItems = [
+            URLQueryItem(name: "client_id", value: clientId),
+            URLQueryItem(name: "response_type", value: responseType),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "scopes", value: scopes),
+            URLQueryItem(name: "show_dialog", value: showDialog)
+        ]
+        return components?.url
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ A proposta é construirmos um aplicativo que nos permite buscar e encontrar mús
 
 4. Assine a linha abaixo, com o seu linkedin, para facilitar o rastreio do projeto:
 
-[Seu Nome e Sobrenome](https://www.linkedin.com/in/sua-url/)
+[Henrique Moutinho Cisi](https://www.linkedin.com/in/henrique-cisi/)
 
 ---


### PR DESCRIPTION
## Descrição
> [Issue - Login com Spotify #21](https://github.com/renew-your-career-ios/find-my-song/issues/21)

Esta PR:
- Implementa fluxo de autenticação com o Spotify via WebView
- Adiciona salvamento seguro de tokens (access e refresh) usando Keychain 
- Integra autenticação biométrica (Face ID / Touch ID)
- Cria tela de busca de músicas após login
- Exibe indicadores de carregamento durante o login e uso de biometria
- Adiciona prompts de ativação de biometria após login bem-sucedido

### Alterações de Interface
Houve alteração de UI?
- [X] Sim
- [ ] Não

#### Evidências
| Antes                             | Depois                                 |
| --------------------------------- | -------------------------------------- |
| Sem login com Spotify             | [Simulator Screenshot - iPhone 16 Pro - 2025-06-10 at 20 49 09](https://github.com/user-attachments/assets/e3ca234b-bb93-4c29-b3df-d3733644dc30)           |
| Sem prompt de biometria    | [Simulator Screenshot - iPhone 16 Pro - 2025-06-10 at 20 49 40](https://github.com/user-attachments/assets/05abc413-6ee5-42cb-b725-8f4780081440) | 
| Sem tela de busca     | [Simulator Screenshot - iPhone 16 Pro - 2025-06-10 at 20 49 45](https://github.com/user-attachments/assets/5defb756-d644-428b-9186-1d69f6bee25a)      |
| Sem feedback visual               | [Simulator Screenshot - iPhone 16 Pro - 2025-06-10 at 20 51 18](https://github.com/user-attachments/assets/41b9d238-ffb0-4b3d-9c06-b68671dd086d) |
